### PR TITLE
BDF parser fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-gtk2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            pkg-config \
+            libgtk2.0-dev \
+            libfreetype6-dev \
+            libx11-dev
+      - name: Build with GTK 2
+        run: make -f Makefile.gtk2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.log
+*.o
+configure
+config.*
+gbdfed

--- a/bdf.c
+++ b/bdf.c
@@ -1560,6 +1560,18 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     }
 
     /*
+     * Check that ENCODING field was present before accessing glyph.
+     */
+    if (!(p->flags & _BDF_ENCODING)) {
+        /*
+         * Missing ENCODING field.
+         */
+        sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "ENCODING");
+        _bdf_add_acmsg(font, nbuf, strlen(nbuf));
+        return BDF_MISSING_ENCODING;
+    }
+
+    /*
      * Point at the glyph being constructed.
      */
     if (p->glyph_enc == -1)
@@ -1617,14 +1629,6 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
      * Expect the SWIDTH (scalable width) field next.
      */
     if (_bdf_strncmp(line, "SWIDTH", 6) == 0) {
-        if (!(p->flags & _BDF_ENCODING)) {
-            /*
-             * Missing ENCODING field.
-             */
-            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "ENCODING");
-            _bdf_add_acmsg(font, nbuf, strlen(nbuf));
-            return BDF_MISSING_ENCODING;
-        }
         _bdf_split(" +", line, linelen, &p->list);
         glyph->swidth = _bdf_atoul(p->list.field[1], 0, 10);
         p->flags |= _BDF_SWIDTH;

--- a/bdf.c
+++ b/bdf.c
@@ -1732,7 +1732,6 @@ _bdf_parse_properties(char *line, unsigned int linelen, unsigned int lineno,
             _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
             p->font->modified = 1;
         }
-        p->flags &= ~_BDF_PROPS;
         *next = _bdf_parse_glyphs;
         return 0;
     }

--- a/bdf.c
+++ b/bdf.c
@@ -1806,7 +1806,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
            * No STARTFONT field is a good indication of a problem.
            */
           return BDF_MISSING_START;
-        p->flags = _BDF_START;
+        p->flags |= _BDF_START;
         p->font = font = (bdf_font_t *) calloc(1, sizeof(bdf_font_t));
         p->font->internal = (void *) malloc(sizeof(hashtable));
         hash_init((hashtable *) p->font->internal);
@@ -2177,7 +2177,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     if (!(p->flags & _BDF_START)) {
         if (memcmp(line, "HBF_START_FONT", 14) != 0)
           return -1;
-        p->flags = _BDF_START;
+        p->flags |= _BDF_START;
         p->font = (bdf_font_t *) calloc(1, sizeof(bdf_font_t));
         /*
          * HBF fonts are always assumed to be 1 bit per pixel.

--- a/bdf.c
+++ b/bdf.c
@@ -1889,6 +1889,14 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
      * Check for the start of the properties.
      */
     if (_bdf_strncmp(line, "STARTPROPERTIES", 15) == 0) {
+        if (!(p->flags & _BDF_FONT_BBX)) {
+            /*
+             * Missing FONTBOUNDINGBOX field.
+             */
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "FONTBOUNDINGBOX");
+            _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
+            return BDF_MISSING_FONTBBX;
+        }
         if (p->flags & _BDF_PROPS) {
             /*
              * STARTPROPERTIES field already seen - this is a duplicate.

--- a/bdf.c
+++ b/bdf.c
@@ -39,6 +39,20 @@
 #define BDF_MAX_GLYPHS 1048576
 
 /*
+ * Auxiliary macro to parse properties and keywords.
+ * It behaves like strncmp but also tests the following character
+ * whether it is whitespace or NULL, ensuring the keyword is complete
+ * and not just a prefix of a longer string.
+ */
+#define _bdf_strncmp(name, keyword, n)     \
+          (strncmp(name, keyword, n) ||    \
+           !(name[n] == ' '  ||             \
+             name[n] == '\0' ||             \
+             name[n] == '\n' ||             \
+             name[n] == '\r' ||             \
+             name[n] == '\t'))
+
+/*
  * Parse flags.
  */
 #define _BDF_START     0x0001
@@ -1230,7 +1244,7 @@ _bdf_add_property(bdf_font_t *font, char *name, char *value)
      * If the property happens to be a comment, then it doesn't need
      * to be added to the internal hash table.
      */
-    if (strncmp(name, "COMMENT", 7) != 0)
+    if (_bdf_strncmp(name, "COMMENT", 7) != 0)
       /*
        * Add the property to the font property table.
        */
@@ -1245,13 +1259,13 @@ _bdf_add_property(bdf_font_t *font, char *name, char *value)
      * and FONT_DESCENT need to be assigned if they are present, and the
      * SPACING property should override the default spacing.
      */
-    if (strncmp(name, "DEFAULT_CHAR", 12) == 0)
+    if (_bdf_strncmp(name, "DEFAULT_CHAR", 12) == 0)
       font->default_glyph = fp->value.int32;
-    else if (strncmp(name, "FONT_ASCENT", 11) == 0)
+    else if (_bdf_strncmp(name, "FONT_ASCENT", 11) == 0)
       font->font_ascent = fp->value.int32;
-    else if (strncmp(name, "FONT_DESCENT", 12) == 0)
+    else if (_bdf_strncmp(name, "FONT_DESCENT", 12) == 0)
       font->font_descent = fp->value.int32;
-    else if (strncmp(name, "SPACING", 7) == 0) {
+    else if (_bdf_strncmp(name, "SPACING", 7) == 0) {
         if (fp->value.atom != 0 && fp->value.atom[0] != 0) {
             if (fp->value.atom[0] == 'p' || fp->value.atom[0] == 'P')
               font->spacing = BDF_PROPORTIONAL;
@@ -1308,7 +1322,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for a comment.
      */
-    if (strncmp(line, "COMMENT", 7) == 0) {
+    if (_bdf_strncmp(line, "COMMENT", 7) == 0) {
         linelen -= 7;
         s = line + 7;
         if (*s != 0) {
@@ -1323,7 +1337,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
      * The very first thing expected is the number of glyphs.
      */
     if (!(p->flags & _BDF_GLYPHS)) {
-        if (strncmp(line, "CHARS", 5) != 0) {
+        if (_bdf_strncmp(line, "CHARS", 5) != 0) {
             sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "CHARS");
             _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
             return BDF_MISSING_CHARS;
@@ -1372,7 +1386,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the ENDFONT field.
      */
-    if (strncmp(line, "ENDFONT", 7) == 0) {
+    if (_bdf_strncmp(line, "ENDFONT", 7) == 0) {
         /*
          * Sort the glyphs by encoding.
          */
@@ -1388,7 +1402,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the ENDCHAR field.
      */
-    if (strncmp(line, "ENDCHAR", 7) == 0) {
+    if (_bdf_strncmp(line, "ENDCHAR", 7) == 0) {
         /*
          * Set up and call the callback if it was passed.
          */
@@ -1422,7 +1436,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the STARTCHAR field.
      */
-    if (strncmp(line, "STARTCHAR", 9) == 0) {
+    if (_bdf_strncmp(line, "STARTCHAR", 9) == 0) {
         if (p->flags & _BDF_GLYPH_BITS) {
             /*
              * Missing ENDCHAR field.
@@ -1450,7 +1464,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the ENCODING field.
      */
-    if (strncmp(line, "ENCODING", 8) == 0) {
+    if (_bdf_strncmp(line, "ENCODING", 8) == 0) {
         if (!(p->flags & _BDF_GLYPH)) {
             /*
              * Missing STARTCHAR field.
@@ -1602,7 +1616,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Expect the SWIDTH (scalable width) field next.
      */
-    if (strncmp(line, "SWIDTH", 6) == 0) {
+    if (_bdf_strncmp(line, "SWIDTH", 6) == 0) {
         if (!(p->flags & _BDF_ENCODING)) {
             /*
              * Missing ENCODING field.
@@ -1620,7 +1634,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Expect the DWIDTH (scalable width) field next.
      */
-    if (strncmp(line, "DWIDTH", 6) == 0) {
+    if (_bdf_strncmp(line, "DWIDTH", 6) == 0) {
         _bdf_split(" +", line, linelen, &p->list);
         glyph->dwidth = _bdf_atoul(p->list.field[1], 0, 10);
 
@@ -1650,7 +1664,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Expect the BBX field next.
      */
-    if (strncmp(line, "BBX", 3) == 0) {
+    if (_bdf_strncmp(line, "BBX", 3) == 0) {
         _bdf_split(" +", line, linelen, &p->list);
         glyph->bbx.width = _bdf_atos(p->list.field[1], 0, 10);
         glyph->bbx.height = _bdf_atos(p->list.field[2], 0, 10);
@@ -1715,7 +1729,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * And finally, gather up the bitmap.
      */
-    if (strncmp(line, "BITMAP", 6) == 0) {
+    if (_bdf_strncmp(line, "BITMAP", 6) == 0) {
         unsigned long bitmap_size;
 
         if (!(p->flags & _BDF_BBX)) {
@@ -1764,7 +1778,7 @@ _bdf_parse_properties(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the end of the properties.
      */
-    if (strncmp(line, "ENDPROPERTIES", 13) == 0) {
+    if (_bdf_strncmp(line, "ENDPROPERTIES", 13) == 0) {
         /*
          * If the FONT_ASCENT or FONT_DESCENT properties have not been
          * encountered yet, then make sure they are added as properties and
@@ -1796,15 +1810,15 @@ _bdf_parse_properties(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Ignore the _XFREE86_GLYPH_RANGES and _XMBDFED_INFO properties.
      */
-    if (strncmp(line, "_XFREE86_GLYPH_RANGES", 21) == 0 ||
-        strncmp(line, "_XMBDFED_INFO", 13) == 0)
+    if (_bdf_strncmp(line, "_XFREE86_GLYPH_RANGES", 21) == 0 ||
+        _bdf_strncmp(line, "_XMBDFED_INFO", 13) == 0)
       return 0;
 
     /*
      * Handle COMMENT fields and properties in a special way to preserve
      * the spacing.
      */
-    if (strncmp(line, "COMMENT", 7) == 0) {
+    if (_bdf_strncmp(line, "COMMENT", 7) == 0) {
         name = value = line;
         value += 7;
         if (*value)
@@ -1843,7 +1857,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
      * Check for a comment.  This is done to handle those fonts that have
      * comments before the STARTFONT line for some reason.
      */
-    if (strncmp(line, "COMMENT", 7) == 0) {
+    if (_bdf_strncmp(line, "COMMENT", 7) == 0) {
         if (p->opts->keep_comments != 0 && p->font != 0) {
             linelen -= 7;
             s = line + 7;
@@ -1857,7 +1871,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     }
 
     if (!(p->flags & _BDF_START)) {
-        if (strncmp(line, "STARTFONT", 9) != 0)
+        if (_bdf_strncmp(line, "STARTFONT", 9) != 0)
           /*
            * No STARTFONT field is a good indication of a problem.
            */
@@ -1874,7 +1888,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the start of the properties.
      */
-    if (strncmp(line, "STARTPROPERTIES", 15) == 0) {
+    if (_bdf_strncmp(line, "STARTPROPERTIES", 15) == 0) {
         if (p->flags & _BDF_PROPS) {
             /*
              * STARTPROPERTIES field already seen - this is a duplicate.
@@ -1908,7 +1922,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the FONTBOUNDINGBOX field.
      */
-    if (strncmp(line, "FONTBOUNDINGBOX", 15) == 0) {
+    if (_bdf_strncmp(line, "FONTBOUNDINGBOX", 15) == 0) {
         if (!(p->flags & _BDF_SIZE)) {
             /*
              * Missing the SIZE field.
@@ -1931,7 +1945,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * The next thing to check for is the FONT field.
      */
-    if (strncmp(line, "FONT", 4) == 0) {
+    if (_bdf_strncmp(line, "FONT", 4) == 0) {
         if (p->flags & _BDF_FONT_NAME) {
             /*
              * FONT field already seen - this is a duplicate.
@@ -1957,7 +1971,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the SIZE field.
      */
-    if (strncmp(line, "SIZE", 4) == 0) {
+    if (_bdf_strncmp(line, "SIZE", 4) == 0) {
         if (!(p->flags & _BDF_FONT_NAME)) {
             /*
              * Missing the FONT field.
@@ -2208,7 +2222,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for comments.
      */
-    if (strncmp(line, "COMMENT", 7) == 0) {
+    if (_bdf_strncmp(line, "COMMENT", 7) == 0) {
         if (p->opts->keep_comments != 0 && p->font != 0) {
             name = line;
             value = name + 7;
@@ -2231,7 +2245,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     }
 
     if (!(p->flags & _BDF_START)) {
-        if (strncmp(line, "HBF_START_FONT", 14) != 0)
+        if (_bdf_strncmp(line, "HBF_START_FONT", 14) != 0)
           return -1;
         p->flags |= _BDF_START;
         p->font = (bdf_font_t *) calloc(1, sizeof(bdf_font_t));
@@ -2250,7 +2264,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the HBF_END_FONT field.
      */
-    if (strncmp(line, "HBF_END_FONT", 12) == 0)
+    if (_bdf_strncmp(line, "HBF_END_FONT", 12) == 0)
       /*
        * Need to perform some checks here to see whether some fields are
        * missing or not.
@@ -2261,7 +2275,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
      * Check for HBF keywords which will be added as comments.  These should
      * never occur in the properties list.  Assume they won't.
      */
-    if (strncmp(line, "HBF_", 4) == 0) {
+    if (_bdf_strncmp(line, "HBF_", 4) == 0) {
         if (p->opts->keep_comments != 0)
           _bdf_add_comment(p->font, line, linelen);
         return 0;
@@ -2271,7 +2285,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the start of the properties.
          */
-        if (strncmp(line, "STARTPROPERTIES", 15) == 0) {
+        if (_bdf_strncmp(line, "STARTPROPERTIES", 15) == 0) {
             _bdf_split(" +", line, linelen, &p->list);
             p->cnt = p->font->props_size = _bdf_atoul(p->list.field[1], 0, 10);
             /*
@@ -2292,7 +2306,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the CHARS field.
          */
-        if (strncmp(line, "CHARS", 5) == 0) {
+        if (_bdf_strncmp(line, "CHARS", 5) == 0) {
             _bdf_split(" +", line, linelen, &p->list);
             p->cnt = p->font->glyphs_size =
                 _bdf_atoul(p->list.field[1], 0, 10);
@@ -2313,7 +2327,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the FONTBOUNDINGBOX field.
          */
-        if (strncmp(line, "FONTBOUNDINGBOX", 15) == 0) {
+        if (_bdf_strncmp(line, "FONTBOUNDINGBOX", 15) == 0) {
             if (!(p->flags & (_BDF_START|_BDF_FONT_NAME|_BDF_SIZE)))
               return -1;
             _bdf_split(" +", line, linelen, &p->list);
@@ -2330,7 +2344,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * The next thing to check for is the FONT field.
          */
-        if (strncmp(line, "FONT", 4) == 0) {
+        if (_bdf_strncmp(line, "FONT", 4) == 0) {
             if (!(p->flags & _BDF_START))
               return -1;
             _bdf_split(" +", line, linelen, &p->list);
@@ -2351,7 +2365,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the SIZE field.
          */
-        if (strncmp(line, "SIZE", 4) == 0) {
+        if (_bdf_strncmp(line, "SIZE", 4) == 0) {
             if (!(p->flags & (_BDF_START|_BDF_FONT_NAME)))
               return -1;
             _bdf_split(" +", line, linelen, &p->list);
@@ -2365,7 +2379,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the end of the properties.
          */
-        if (strncmp(line, "ENDPROPERTIES", 13) == 0) {
+        if (_bdf_strncmp(line, "ENDPROPERTIES", 13) == 0) {
             /*
              * If the FONT_ASCENT or FONT_DESCENT properties have not been
              * encountered yet, then make sure they are added as properties and
@@ -3739,7 +3753,7 @@ bdf_delete_font_property(bdf_font_t *font, char *name)
      * If the font property happens to be DEFAULT_CHAR, then make sure the
      * default_glyph field is reset.
      */
-    if (strncmp(name, "DEFAULT_CHAR", 12) == 0)
+    if (_bdf_strncmp(name, "DEFAULT_CHAR", 12) == 0)
       font->default_glyph = -1;
 
     /*

--- a/bdf.c
+++ b/bdf.c
@@ -988,19 +988,25 @@ _bdf_add_comment(bdf_font_t *font, char *comment, unsigned int len)
 static void
 _bdf_set_default_spacing(bdf_font_t *font, bdf_options_t *opts)
 {
-    unsigned int len;
     char name[128];
     _bdf_list_t list;
+    size_t n;
 
     if (font == 0 || font->name == 0 || font->name[0] == 0)
       return;
 
     font->spacing = opts->font_spacing;
 
-    len = (unsigned int) (strlen(font->name) + 1);
-    (void) memcpy(name, font->name, len);
+    n = strlen(font->name);
+    if (n > sizeof(name) - 1)
+      n = sizeof(name) - 1;
+    (void) memcpy(name, font->name, n);
+    /*
+     * Ensure termination even when the name is truncated.
+     */
+    name[n] = '\0';
     list.size = list.used = 0;
-    _bdf_split("-", name, len, &list);
+    _bdf_split("-", name, (unsigned int) (n + 1), &list);
     if (list.used == 15) {
         switch (list.field[11][0]) {
           case 'C': case 'c': font->spacing = BDF_CHARCELL; break;

--- a/bdf.c
+++ b/bdf.c
@@ -20,6 +20,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 #include "bdfP.h"
+#include <limits.h>
 
 #ifdef HAVE_HBF
 #include "hbf.h"
@@ -769,7 +770,15 @@ _bdf_atoul(char *s, char **end, int base)
     }
 
     for (v = 0; *s && sbitset(dmap, *s); s++)
-      v = (v * base) + a2i[(int) *s];
+    {
+      if (v < (UINT_MAX - (base - 1)) / base)
+        v = (v * base) + a2i[(int) *s];
+      else
+      {
+        v = UINT_MAX;
+        break;
+      }
+    }
 
     if (end != 0)
       *end = s;
@@ -818,7 +827,15 @@ _bdf_atol(char *s, char **end, int base)
     }
 
     for (v = 0; *s && sbitset(dmap, *s); s++)
-      v = (v * base) + a2i[(int) *s];
+    {
+      if (v < (INT_MAX - (base - 1)) / base)
+        v = (v * base) + a2i[(int) *s];
+      else
+      {
+        v = INT_MAX;
+        break;
+      }
+    }
 
     if (end != 0)
       *end = s;
@@ -866,7 +883,15 @@ _bdf_atos(char *s, char **end, int base)
     }
 
     for (v = 0; *s && sbitset(dmap, *s); s++)
-      v = (v * base) + a2i[(int) *s];
+    {
+      if (v < (SHRT_MAX - (base - 1)) / base)
+        v = (v * base) + a2i[(int) *s];
+      else
+      {
+        v = SHRT_MAX;
+        break;
+      }
+    }
 
     if (end != 0)
       *end = s;

--- a/bdf.c
+++ b/bdf.c
@@ -366,8 +366,10 @@ typedef struct {
     _bdf_list_t list;
 } _bdf_parse_t;
 
-#define setsbit(m, cc) (m[(cc) >> 3] |= (1 << ((cc) & 7)))
-#define sbitset(m, cc) (m[(cc) >> 3] & (1 << ((cc) & 7)))
+#define setsbit(m, cc) \
+    (m[((unsigned char)(cc)) >> 3] |= (1 << (((unsigned char)(cc)) & 7)))
+#define sbitset(m, cc) \
+    (m[((unsigned char)(cc)) >> 3] & (1 << (((unsigned char)(cc)) & 7)))
 
 /*
  * An empty string for empty fields.

--- a/bdf.c
+++ b/bdf.c
@@ -5730,7 +5730,7 @@ bdf_has_xlfd_name(bdf_font_t *font)
 }
 
 char *
-bdf_make_xlfd_name(bdf_font_t *font, char *foundry, char *family)
+bdf_make_xlfd_name(bdf_font_t *font, const char *foundry, const char *family)
 {
     int len;
     double dp, dr;

--- a/bdf.c
+++ b/bdf.c
@@ -3174,7 +3174,7 @@ bdf_free_font(bdf_font_t *font)
           free(font->props[i].value.atom);
     }
 
-    if (font->props_size > 0 && font->props != 0)
+    if (font->props != 0)
       free((char *) font->props);
 
     /*
@@ -3197,10 +3197,10 @@ bdf_free_font(bdf_font_t *font)
           free((char *) glyphs->unicode.map);
     }
 
-    if (font->glyphs_size > 0)
+    if (font->glyphs != 0)
       free((char *) font->glyphs);
 
-    if (font->unencoded_size > 0)
+    if (font->unencoded != 0)
       free((char *) font->unencoded);
 
     /*
@@ -3215,7 +3215,7 @@ bdf_free_font(bdf_font_t *font)
         if (glyphs->unicode.map_size > 0)
           free((char *) glyphs->unicode.map);
     }
-    if (font->overflow.glyphs_size > 0)
+    if (font->overflow.glyphs != 0)
       free((char *) font->overflow.glyphs);
 
     free((char *) font);

--- a/bdf.c
+++ b/bdf.c
@@ -1224,12 +1224,14 @@ _bdf_add_property(bdf_font_t *font, char *name, char *value)
     else if (memcmp(name, "FONT_DESCENT", 12) == 0)
       font->font_descent = fp->value.int32;
     else if (memcmp(name, "SPACING", 7) == 0) {
-        if (fp->value.atom[0] == 'p' || fp->value.atom[0] == 'P')
-          font->spacing = BDF_PROPORTIONAL;
-        else if (fp->value.atom[0] == 'm' || fp->value.atom[0] == 'M')
-          font->spacing = BDF_MONOWIDTH;
-        else if (fp->value.atom[0] == 'c' || fp->value.atom[0] == 'C')
-          font->spacing = BDF_CHARCELL;
+        if (fp->value.atom != 0 && fp->value.atom[0] != 0) {
+            if (fp->value.atom[0] == 'p' || fp->value.atom[0] == 'P')
+              font->spacing = BDF_PROPORTIONAL;
+            else if (fp->value.atom[0] == 'm' || fp->value.atom[0] == 'M')
+              font->spacing = BDF_MONOWIDTH;
+            else if (fp->value.atom[0] == 'c' || fp->value.atom[0] == 'C')
+              font->spacing = BDF_CHARCELL;
+        }
     }
 }
 

--- a/bdf.c
+++ b/bdf.c
@@ -1228,7 +1228,7 @@ _bdf_add_property(bdf_font_t *font, char *name, char *value)
      * If the property happens to be a comment, then it doesn't need
      * to be added to the internal hash table.
      */
-    if (memcmp(name, "COMMENT", 7) != 0)
+    if (strncmp(name, "COMMENT", 7) != 0)
       /*
        * Add the property to the font property table.
        */
@@ -1243,13 +1243,13 @@ _bdf_add_property(bdf_font_t *font, char *name, char *value)
      * and FONT_DESCENT need to be assigned if they are present, and the
      * SPACING property should override the default spacing.
      */
-    if (memcmp(name, "DEFAULT_CHAR", 12) == 0)
+    if (strncmp(name, "DEFAULT_CHAR", 12) == 0)
       font->default_glyph = fp->value.int32;
-    else if (memcmp(name, "FONT_ASCENT", 11) == 0)
+    else if (strncmp(name, "FONT_ASCENT", 11) == 0)
       font->font_ascent = fp->value.int32;
-    else if (memcmp(name, "FONT_DESCENT", 12) == 0)
+    else if (strncmp(name, "FONT_DESCENT", 12) == 0)
       font->font_descent = fp->value.int32;
-    else if (memcmp(name, "SPACING", 7) == 0) {
+    else if (strncmp(name, "SPACING", 7) == 0) {
         if (fp->value.atom != 0 && fp->value.atom[0] != 0) {
             if (fp->value.atom[0] == 'p' || fp->value.atom[0] == 'P')
               font->spacing = BDF_PROPORTIONAL;
@@ -1306,7 +1306,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for a comment.
      */
-    if (memcmp(line, "COMMENT", 7) == 0) {
+    if (strncmp(line, "COMMENT", 7) == 0) {
         linelen -= 7;
         s = line + 7;
         if (*s != 0) {
@@ -1321,7 +1321,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
      * The very first thing expected is the number of glyphs.
      */
     if (!(p->flags & _BDF_GLYPHS)) {
-        if (memcmp(line, "CHARS", 5) != 0) {
+        if (strncmp(line, "CHARS", 5) != 0) {
             sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "CHARS");
             _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
             return BDF_MISSING_CHARS;
@@ -1370,7 +1370,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the ENDFONT field.
      */
-    if (memcmp(line, "ENDFONT", 7) == 0) {
+    if (strncmp(line, "ENDFONT", 7) == 0) {
         /*
          * Sort the glyphs by encoding.
          */
@@ -1386,7 +1386,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the ENDCHAR field.
      */
-    if (memcmp(line, "ENDCHAR", 7) == 0) {
+    if (strncmp(line, "ENDCHAR", 7) == 0) {
         /*
          * Set up and call the callback if it was passed.
          */
@@ -1420,7 +1420,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the STARTCHAR field.
      */
-    if (memcmp(line, "STARTCHAR", 9) == 0) {
+    if (strncmp(line, "STARTCHAR", 9) == 0) {
         if (p->flags & _BDF_GLYPH_BITS) {
             /*
              * Missing ENDCHAR field.
@@ -1448,7 +1448,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the ENCODING field.
      */
-    if (memcmp(line, "ENCODING", 8) == 0) {
+    if (strncmp(line, "ENCODING", 8) == 0) {
         if (!(p->flags & _BDF_GLYPH)) {
             /*
              * Missing STARTCHAR field.
@@ -1600,7 +1600,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Expect the SWIDTH (scalable width) field next.
      */
-    if (memcmp(line, "SWIDTH", 6) == 0) {
+    if (strncmp(line, "SWIDTH", 6) == 0) {
         if (!(p->flags & _BDF_ENCODING)) {
             /*
              * Missing ENCODING field.
@@ -1618,7 +1618,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Expect the DWIDTH (scalable width) field next.
      */
-    if (memcmp(line, "DWIDTH", 6) == 0) {
+    if (strncmp(line, "DWIDTH", 6) == 0) {
         _bdf_split(" +", line, linelen, &p->list);
         glyph->dwidth = _bdf_atoul(p->list.field[1], 0, 10);
 
@@ -1648,7 +1648,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Expect the BBX field next.
      */
-    if (memcmp(line, "BBX", 3) == 0) {
+    if (strncmp(line, "BBX", 3) == 0) {
         _bdf_split(" +", line, linelen, &p->list);
         glyph->bbx.width = _bdf_atos(p->list.field[1], 0, 10);
         glyph->bbx.height = _bdf_atos(p->list.field[2], 0, 10);
@@ -1713,7 +1713,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * And finally, gather up the bitmap.
      */
-    if (memcmp(line, "BITMAP", 6) == 0) {
+    if (strncmp(line, "BITMAP", 6) == 0) {
         unsigned long bitmap_size;
 
         if (!(p->flags & _BDF_BBX)) {
@@ -1762,7 +1762,7 @@ _bdf_parse_properties(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the end of the properties.
      */
-    if (memcmp(line, "ENDPROPERTIES", 13) == 0) {
+    if (strncmp(line, "ENDPROPERTIES", 13) == 0) {
         /*
          * If the FONT_ASCENT or FONT_DESCENT properties have not been
          * encountered yet, then make sure they are added as properties and
@@ -1794,15 +1794,15 @@ _bdf_parse_properties(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Ignore the _XFREE86_GLYPH_RANGES and _XMBDFED_INFO properties.
      */
-    if (memcmp(line, "_XFREE86_GLYPH_RANGES", 21) == 0 ||
-        memcmp(line, "_XMBDFED_INFO", 13) == 0)
+    if (strncmp(line, "_XFREE86_GLYPH_RANGES", 21) == 0 ||
+        strncmp(line, "_XMBDFED_INFO", 13) == 0)
       return 0;
 
     /*
      * Handle COMMENT fields and properties in a special way to preserve
      * the spacing.
      */
-    if (memcmp(line, "COMMENT", 7) == 0) {
+    if (strncmp(line, "COMMENT", 7) == 0) {
         name = value = line;
         value += 7;
         if (*value)
@@ -1841,7 +1841,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
      * Check for a comment.  This is done to handle those fonts that have
      * comments before the STARTFONT line for some reason.
      */
-    if (memcmp(line, "COMMENT", 7) == 0) {
+    if (strncmp(line, "COMMENT", 7) == 0) {
         if (p->opts->keep_comments != 0 && p->font != 0) {
             linelen -= 7;
             s = line + 7;
@@ -1855,7 +1855,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     }
 
     if (!(p->flags & _BDF_START)) {
-        if (memcmp(line, "STARTFONT", 9) != 0)
+        if (strncmp(line, "STARTFONT", 9) != 0)
           /*
            * No STARTFONT field is a good indication of a problem.
            */
@@ -1872,7 +1872,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the start of the properties.
      */
-    if (memcmp(line, "STARTPROPERTIES", 15) == 0) {
+    if (strncmp(line, "STARTPROPERTIES", 15) == 0) {
         if (p->flags & _BDF_PROPS) {
             /*
              * STARTPROPERTIES field already seen - this is a duplicate.
@@ -1906,7 +1906,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the FONTBOUNDINGBOX field.
      */
-    if (memcmp(line, "FONTBOUNDINGBOX", 15) == 0) {
+    if (strncmp(line, "FONTBOUNDINGBOX", 15) == 0) {
         if (!(p->flags & _BDF_SIZE)) {
             /*
              * Missing the SIZE field.
@@ -1929,7 +1929,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * The next thing to check for is the FONT field.
      */
-    if (memcmp(line, "FONT", 4) == 0) {
+    if (strncmp(line, "FONT", 4) == 0) {
         if (p->flags & _BDF_FONT_NAME) {
             /*
              * FONT field already seen - this is a duplicate.
@@ -1955,7 +1955,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the SIZE field.
      */
-    if (memcmp(line, "SIZE", 4) == 0) {
+    if (strncmp(line, "SIZE", 4) == 0) {
         if (!(p->flags & _BDF_FONT_NAME)) {
             /*
              * Missing the FONT field.
@@ -2206,7 +2206,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for comments.
      */
-    if (memcmp(line, "COMMENT", 7) == 0) {
+    if (strncmp(line, "COMMENT", 7) == 0) {
         if (p->opts->keep_comments != 0 && p->font != 0) {
             name = line;
             value = name + 7;
@@ -2229,7 +2229,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     }
 
     if (!(p->flags & _BDF_START)) {
-        if (memcmp(line, "HBF_START_FONT", 14) != 0)
+        if (strncmp(line, "HBF_START_FONT", 14) != 0)
           return -1;
         p->flags |= _BDF_START;
         p->font = (bdf_font_t *) calloc(1, sizeof(bdf_font_t));
@@ -2248,7 +2248,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
     /*
      * Check for the HBF_END_FONT field.
      */
-    if (memcmp(line, "HBF_END_FONT", 12) == 0)
+    if (strncmp(line, "HBF_END_FONT", 12) == 0)
       /*
        * Need to perform some checks here to see whether some fields are
        * missing or not.
@@ -2259,7 +2259,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
      * Check for HBF keywords which will be added as comments.  These should
      * never occur in the properties list.  Assume they won't.
      */
-    if (memcmp(line, "HBF_", 4) == 0) {
+    if (strncmp(line, "HBF_", 4) == 0) {
         if (p->opts->keep_comments != 0)
           _bdf_add_comment(p->font, line, linelen);
         return 0;
@@ -2269,7 +2269,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the start of the properties.
          */
-        if (memcmp(line, "STARTPROPERTIES", 15) == 0) {
+        if (strncmp(line, "STARTPROPERTIES", 15) == 0) {
             _bdf_split(" +", line, linelen, &p->list);
             p->cnt = p->font->props_size = _bdf_atoul(p->list.field[1], 0, 10);
             /*
@@ -2290,7 +2290,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the CHARS field.
          */
-        if (memcmp(line, "CHARS", 5) == 0) {
+        if (strncmp(line, "CHARS", 5) == 0) {
             _bdf_split(" +", line, linelen, &p->list);
             p->cnt = p->font->glyphs_size =
                 _bdf_atoul(p->list.field[1], 0, 10);
@@ -2311,7 +2311,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the FONTBOUNDINGBOX field.
          */
-        if (memcmp(line, "FONTBOUNDINGBOX", 15) == 0) {
+        if (strncmp(line, "FONTBOUNDINGBOX", 15) == 0) {
             if (!(p->flags & (_BDF_START|_BDF_FONT_NAME|_BDF_SIZE)))
               return -1;
             _bdf_split(" +", line, linelen, &p->list);
@@ -2328,7 +2328,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * The next thing to check for is the FONT field.
          */
-        if (memcmp(line, "FONT", 4) == 0) {
+        if (strncmp(line, "FONT", 4) == 0) {
             if (!(p->flags & _BDF_START))
               return -1;
             _bdf_split(" +", line, linelen, &p->list);
@@ -2349,7 +2349,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the SIZE field.
          */
-        if (memcmp(line, "SIZE", 4) == 0) {
+        if (strncmp(line, "SIZE", 4) == 0) {
             if (!(p->flags & (_BDF_START|_BDF_FONT_NAME)))
               return -1;
             _bdf_split(" +", line, linelen, &p->list);
@@ -2363,7 +2363,7 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         /*
          * Check for the end of the properties.
          */
-        if (memcmp(line, "ENDPROPERTIES", 13) == 0) {
+        if (strncmp(line, "ENDPROPERTIES", 13) == 0) {
             /*
              * If the FONT_ASCENT or FONT_DESCENT properties have not been
              * encountered yet, then make sure they are added as properties and

--- a/bdf.c
+++ b/bdf.c
@@ -1786,8 +1786,12 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
         }
         _bdf_split(" +", line, linelen, &p->list);
         p->cnt = p->font->props_size = _bdf_atoul(p->list.field[1], 0, 10);
-        p->font->props = (bdf_property_t *)
-            malloc(sizeof(bdf_property_t) * p->cnt);
+        if (p->cnt > 0) {
+            p->font->props = (bdf_property_t *)
+                malloc(sizeof(bdf_property_t) * p->cnt);
+        } else {
+            p->font->props = 0;
+        }
         p->flags |= _BDF_PROPS;
         *next = _bdf_parse_properties;
         return 0;
@@ -2162,8 +2166,12 @@ _bdf_parse_hbf_header(char *line, unsigned int linelen, unsigned int lineno,
         if (memcmp(line, "STARTPROPERTIES", 15) == 0) {
             _bdf_split(" +", line, linelen, &p->list);
             p->cnt = p->font->props_size = _bdf_atoul(p->list.field[1], 0, 10);
-            p->font->props = (bdf_property_t *)
-                malloc(sizeof(bdf_property_t) * p->cnt);
+            if (p->cnt > 0) {
+                p->font->props = (bdf_property_t *)
+                    malloc(sizeof(bdf_property_t) * p->cnt);
+            } else {
+                p->font->props = 0;
+            }
             p->flags |= _BDF_PROPS;
             return 0;
         }

--- a/bdf.c
+++ b/bdf.c
@@ -1262,6 +1262,25 @@ _bdf_add_property(bdf_font_t *font, char *name, char *value)
 }
 
 /*
+ * No-op function to ignore data after ENDFONT.
+ */
+static int
+_bdf_parse_end(char *line, unsigned int linelen, unsigned int lineno,
+               void *call_data, void *client_data)
+{
+    /*
+     * A no-op; we ignore everything after ENDFONT.
+     */
+    (void) line;
+    (void) linelen;
+    (void) lineno;
+    (void) call_data;
+    (void) client_data;
+
+    return 0;
+}
+
+/*
  * Actually parse the glyph info and bitmaps.
  */
 static int
@@ -1359,6 +1378,8 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
               by_encoding);
 
         p->flags &= ~_BDF_START;
+        *next = _bdf_parse_end;
+
         return 0;
     }
 

--- a/bdf.c
+++ b/bdf.c
@@ -2843,14 +2843,14 @@ bdf_save_font(FILE *out, bdf_font_t *font, bdf_options_t *opts,
         bpr = ((c->bbx.width * font->bpp) + 7) >> 3;
         for (j = 0; bpr != 0 && j < c->bytes; j++) {
             if (j && j % bpr == 0)
-              fprintf(out, eol);
+              fprintf(out, "%s", eol);
             fprintf(out, "%02X", c->bitmap[j]);
         }
         /*
          * Handle empty bitmaps like this.
          */
         if (c->bbx.height > 0)
-          fprintf(out, eol);
+          fprintf(out, "%s", eol);
         fprintf(out, "ENDCHAR%s", eol);
 
         /*
@@ -2915,14 +2915,14 @@ bdf_save_font(FILE *out, bdf_font_t *font, bdf_options_t *opts,
         bpr = ((c->bbx.width * font->bpp) + 7) >> 3;
         for (j = 0; bpr != 0 && j < c->bytes; j++) {
             if (j && j % bpr == 0)
-              fprintf(out, eol);
+              fprintf(out, "%s", eol);
             fprintf(out, "%02X", c->bitmap[j]);
         }
         /*
          * Handle empty bitmaps like this.
          */
         if (c->bbx.height > 0)
-          fprintf(out, eol);
+          fprintf(out, "%s", eol);
         fprintf(out, "ENDCHAR%s", eol);
 
         /*

--- a/bdf.c
+++ b/bdf.c
@@ -764,7 +764,7 @@ _bdf_atoul(char *s, char **end, int base)
         s += 2;
     }
 
-    for (v = 0; isdigok(dmap, *s); s++)
+    for (v = 0; *s && isdigok(dmap, *s); s++)
       v = (v * base) + a2i[(int) *s];
 
     if (end != 0)
@@ -813,7 +813,7 @@ _bdf_atol(char *s, char **end, int base)
         s += 2;
     }
 
-    for (v = 0; isdigok(dmap, *s); s++)
+    for (v = 0; *s && isdigok(dmap, *s); s++)
       v = (v * base) + a2i[(int) *s];
 
     if (end != 0)
@@ -861,7 +861,7 @@ _bdf_atos(char *s, char **end, int base)
         s += 2;
     }
 
-    for (v = 0; isdigok(dmap, *s); s++)
+    for (v = 0; *s && isdigok(dmap, *s); s++)
       v = (v * base) + a2i[(int) *s];
 
     if (end != 0)

--- a/bdf.c
+++ b/bdf.c
@@ -38,6 +38,62 @@
 #define BDF_MAX_PROPERTIES 32768
 #define BDF_MAX_GLYPHS 1048576
 
+/*
+ * Parse flags.
+ */
+#define _BDF_START     0x0001
+#define _BDF_FONT_NAME 0x0002
+#define _BDF_SIZE      0x0004
+#define _BDF_FONT_BBX  0x0008
+#define _BDF_PROPS     0x0010
+#define _BDF_GLYPHS    0x0020
+#define _BDF_GLYPH     0x0040
+#define _BDF_ENCODING  0x0080
+#define _BDF_SWIDTH    0x0100
+#define _BDF_DWIDTH    0x0200
+#define _BDF_BBX       0x0400
+#define _BDF_BITMAP    0x0800
+
+#define _BDF_SWIDTH_ADJ 0x1000
+
+#define _BDF_GLYPH_BITS (_BDF_GLYPH|_BDF_ENCODING|_BDF_SWIDTH|\
+                         _BDF_DWIDTH|_BDF_BBX|_BDF_BITMAP)
+
+#define _BDF_GLYPH_WIDTH_CHECK 0x40000000
+#define _BDF_GLYPH_HEIGHT_CHECK 0x80000000
+
+/*
+ * Auto correction messages.
+ */
+#define ACMSG1 "FONT_ASCENT property missing.  Added \"FONT_ASCENT %hd\"."
+#define ACMSG2 "FONT_DESCENT property missing.  Added \"FONT_DESCENT %hd\"."
+#define ACMSG3 "Font width != actual width.  Old: %hd New: %hd."
+#define ACMSG4 "Font left bearing != actual left bearing.  Old: %hd New: %hd."
+#define ACMSG5 "Font ascent != actual ascent.  Old: %hd New: %hd."
+#define ACMSG6 "Font descent != actual descent.  Old: %hd New: %hd."
+#define ACMSG7 "Font height != actual height. Old: %hd New: %hd."
+#define ACMSG8 "Glyph scalable width (SWIDTH) adjustments made."
+#define ACMSG9 "SWIDTH field missing at line %d.  Set automatically."
+#define ACMSG10 "DWIDTH field missing at line %d.  Set to glyph width."
+#define ACMSG11 "SIZE bits per pixel field adjusted to %hd."
+#define ACMSG12 "Duplicate encoding %d (%s) changed to unencoded."
+#define ACMSG13 "Glyph %d extra rows removed."
+#define ACMSG14 "Glyph %d extra columns removed."
+#define ACMSG15 "Incorrect glyph count: %d indicated but %d found."
+
+/*
+ * Error messages.
+ */
+#define BDF_ERR_MISSING_FIELD "[line %d] Missing \"%s\" line."
+#define BDF_ERR_CORRUPT_HEADER "[line %d] Font header corrupted or missing fields."
+#define BDF_ERR_CORRUPT_GLYPHS "[line %d] Font glyphs corrupted or missing fields."
+#define BDF_ERR_DUPLICATE_FIELD "[line %d] Duplicate \"%s\" field."
+#define BDF_ERR_BBX_TOO_BIG "[line %d] BBX too big."
+#define BDF_ERR_TOO_MANY_PROPERTIES "[line %ld] Excessive number of properties %u."
+#define BDF_ERR_TOO_MANY_GLYPHS "[line %ld] Excessive number of glyphs %u."
+
+
+
 /**************************************************************************
  *
  * Masks used for checking different bits per pixel cases.
@@ -921,60 +977,6 @@ by_encoding(const void *a, const void *b)
  * BDF font file parsing flags and functions.
  *
  **************************************************************************/
-
-/*
- * Parse flags.
- */
-#define _BDF_START     0x0001
-#define _BDF_FONT_NAME 0x0002
-#define _BDF_SIZE      0x0004
-#define _BDF_FONT_BBX  0x0008
-#define _BDF_PROPS     0x0010
-#define _BDF_GLYPHS    0x0020
-#define _BDF_GLYPH     0x0040
-#define _BDF_ENCODING  0x0080
-#define _BDF_SWIDTH    0x0100
-#define _BDF_DWIDTH    0x0200
-#define _BDF_BBX       0x0400
-#define _BDF_BITMAP    0x0800
-
-#define _BDF_SWIDTH_ADJ 0x1000
-
-#define _BDF_GLYPH_BITS (_BDF_GLYPH|_BDF_ENCODING|_BDF_SWIDTH|\
-                         _BDF_DWIDTH|_BDF_BBX|_BDF_BITMAP)
-
-#define _BDF_GLYPH_WIDTH_CHECK 0x40000000
-#define _BDF_GLYPH_HEIGHT_CHECK 0x80000000
-
-/*
- * Auto correction messages.
- */
-#define ACMSG1 "FONT_ASCENT property missing.  Added \"FONT_ASCENT %hd\"."
-#define ACMSG2 "FONT_DESCENT property missing.  Added \"FONT_DESCENT %hd\"."
-#define ACMSG3 "Font width != actual width.  Old: %hd New: %hd."
-#define ACMSG4 "Font left bearing != actual left bearing.  Old: %hd New: %hd."
-#define ACMSG5 "Font ascent != actual ascent.  Old: %hd New: %hd."
-#define ACMSG6 "Font descent != actual descent.  Old: %hd New: %hd."
-#define ACMSG7 "Font height != actual height. Old: %hd New: %hd."
-#define ACMSG8 "Glyph scalable width (SWIDTH) adjustments made."
-#define ACMSG9 "SWIDTH field missing at line %d.  Set automatically."
-#define ACMSG10 "DWIDTH field missing at line %d.  Set to glyph width."
-#define ACMSG11 "SIZE bits per pixel field adjusted to %hd."
-#define ACMSG12 "Duplicate encoding %d (%s) changed to unencoded."
-#define ACMSG13 "Glyph %d extra rows removed."
-#define ACMSG14 "Glyph %d extra columns removed."
-#define ACMSG15 "Incorrect glyph count: %d indicated but %d found."
-
-/*
- * Error messages.
- */
-#define BDF_ERR_MISSING_FIELD "[line %d] Missing \"%s\" line."
-#define BDF_ERR_CORRUPT_HEADER "[line %d] Font header corrupted or missing fields."
-#define BDF_ERR_CORRUPT_GLYPHS "[line %d] Font glyphs corrupted or missing fields."
-#define BDF_ERR_DUPLICATE_FIELD "[line %d] Duplicate \"%s\" field."
-#define BDF_ERR_BBX_TOO_BIG "[line %d] BBX too big."
-#define BDF_ERR_TOO_MANY_PROPERTIES "[line %ld] Excessive number of properties %u."
-#define BDF_ERR_TOO_MANY_GLYPHS "[line %ld] Excessive number of glyphs %u."
 
 void
 _bdf_add_acmsg(bdf_font_t *font, char *msg, unsigned int len)

--- a/bdf.c
+++ b/bdf.c
@@ -939,9 +939,9 @@ by_encoding(const void *a, const void *b)
 /*
  * Error messages.
  */
-#define ERRMSG1 "[line %d] Missing \"%s\" line."
-#define ERRMSG2 "[line %d] Font header corrupted or missing fields."
-#define ERRMSG3 "[line %d] Font glyphs corrupted or missing fields."
+#define BDF_ERR_MISSING_FIELD "[line %d] Missing \"%s\" line."
+#define BDF_ERR_CORRUPT_HEADER "[line %d] Font header corrupted or missing fields."
+#define BDF_ERR_CORRUPT_GLYPHS "[line %d] Font glyphs corrupted or missing fields."
 
 void
 _bdf_add_acmsg(bdf_font_t *font, char *msg, unsigned int len)
@@ -1268,7 +1268,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
      */
     if (!(p->flags & _BDF_GLYPHS)) {
         if (memcmp(line, "CHARS", 5) != 0) {
-            sprintf(nbuf, ERRMSG1, lineno, "CHARS");
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "CHARS");
             _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
             return BDF_MISSING_CHARS;
         }
@@ -1370,7 +1370,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
             /*
              * Missing STARTCHAR field.
              */
-            sprintf(nbuf, ERRMSG1, lineno, "STARTCHAR");
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "STARTCHAR");
             _bdf_add_acmsg(font, nbuf, strlen(nbuf));
             return BDF_MISSING_STARTCHAR;
         }
@@ -1522,7 +1522,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
             /*
              * Missing ENCODING field.
              */
-            sprintf(nbuf, ERRMSG1, lineno, "ENCODING");
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "ENCODING");
             _bdf_add_acmsg(font, nbuf, strlen(nbuf));
             return BDF_MISSING_ENCODING;
         }
@@ -1629,7 +1629,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
             /*
              * Missing BBX field.
              */
-            sprintf(nbuf, ERRMSG1, lineno, "BBX");
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "BBX");
             _bdf_add_acmsg(font, nbuf, strlen(nbuf));
             return BDF_MISSING_BBX;
         }
@@ -1794,7 +1794,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
             /*
              * Missing the SIZE field.
              */
-            sprintf(nbuf, ERRMSG1, lineno, "SIZE");
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "SIZE");
             _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
             return BDF_MISSING_SIZE;
         }
@@ -1835,7 +1835,7 @@ _bdf_parse_start(char *line, unsigned int linelen, unsigned int lineno,
             /*
              * Missing the FONT field.
              */
-            sprintf(nbuf, ERRMSG1, lineno, "FONT");
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "FONT");
             _bdf_add_acmsg(p->font, nbuf, strlen(nbuf));
             return BDF_MISSING_FONTNAME;
         }
@@ -2010,12 +2010,12 @@ bdf_load_font(FILE *in, bdf_options_t *opts, bdf_callback_t callback,
               /*
                * Error happened while parsing header.
                */
-              sprintf(msgbuf, ERRMSG2, lineno);
+              sprintf(msgbuf, BDF_ERR_CORRUPT_HEADER, lineno);
             else
               /*
                * Error happened when parsing glyphs.
                */
-              sprintf(msgbuf, ERRMSG3, lineno);
+              sprintf(msgbuf, BDF_ERR_CORRUPT_GLYPHS, lineno);
 
             _bdf_add_acmsg(p.font, msgbuf, strlen(msgbuf));
         }

--- a/bdf.c
+++ b/bdf.c
@@ -1577,6 +1577,12 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
     }
 
     /*
+     * Do not leak the bitmap or reset its size.
+     */
+    if (p->flags & _BDF_BITMAP)
+      return BDF_INVALID_LINE;
+
+    /*
      * Expect the BBX field next.
      */
     if (memcmp(line, "BBX", 3) == 0) {

--- a/bdf.c
+++ b/bdf.c
@@ -1708,7 +1708,7 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
          */
         p->bpr = ((glyph->bbx.width * p->font->bpp) + 7) >> 3;
         bitmap_size = p->bpr * glyph->bbx.height;
-        if (bitmap_size > 0xFFFFU) {
+        if (p->bpr > 0xFFFFU || bitmap_size > 0xFFFFU) {
             sprintf(nbuf, BDF_ERR_BBX_TOO_BIG, lineno);
             _bdf_add_acmsg(font, nbuf, strlen(nbuf));
             return BDF_BBX_TOO_BIG;

--- a/bdf.c
+++ b/bdf.c
@@ -1350,6 +1350,14 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
             p->cb.current = font->glyphs_used;
             (*p->callback)(&p->cb, p->client_data);
         }
+
+        /*
+         * Free unused glyph_name.
+         */
+        if (p->glyph_name != 0)
+          free(p->glyph_name);
+        p->glyph_name = 0;
+
         p->glyph_enc = 0;
         p->flags &= ~_BDF_GLYPH_BITS;
         return 0;

--- a/bdf.c
+++ b/bdf.c
@@ -731,8 +731,6 @@ static unsigned char hdigits[32] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-#define isdigok(m, d) (m[(d) >> 3] & (1 << ((d) & 7)))
-
 /*
  * Routine to convert an ASCII string into an unsigned int integer.
  */
@@ -764,7 +762,7 @@ _bdf_atoul(char *s, char **end, int base)
         s += 2;
     }
 
-    for (v = 0; *s && isdigok(dmap, *s); s++)
+    for (v = 0; *s && sbitset(dmap, *s); s++)
       v = (v * base) + a2i[(int) *s];
 
     if (end != 0)
@@ -813,7 +811,7 @@ _bdf_atol(char *s, char **end, int base)
         s += 2;
     }
 
-    for (v = 0; *s && isdigok(dmap, *s); s++)
+    for (v = 0; *s && sbitset(dmap, *s); s++)
       v = (v * base) + a2i[(int) *s];
 
     if (end != 0)
@@ -861,7 +859,7 @@ _bdf_atos(char *s, char **end, int base)
         s += 2;
     }
 
-    for (v = 0; *s && isdigok(dmap, *s); s++)
+    for (v = 0; *s && sbitset(dmap, *s); s++)
       v = (v * base) + a2i[(int) *s];
 
     if (end != 0)

--- a/bdf.c
+++ b/bdf.c
@@ -3218,54 +3218,55 @@ bdf_free_font(bdf_font_t *font)
     /*
      * Free up the properties.
      */
-    for (i = 0; i < font->props_size; i++) {
-        if (font->props[i].format == BDF_ATOM && font->props[i].value.atom)
-          free(font->props[i].value.atom);
+    if (font->props != 0) {
+        for (i = 0; i < font->props_size; i++) {
+            if (font->props[i].format == BDF_ATOM && font->props[i].value.atom)
+              free(font->props[i].value.atom);
+        }
+        free((char *) font->props);
     }
-
-    if (font->props != 0)
-      free((char *) font->props);
 
     /*
      * Free up the character info.
      */
-    for (i = 0, glyphs = font->glyphs; i < font->glyphs_used; i++, glyphs++) {
-        if (glyphs->name)
-          free(glyphs->name);
-        if (glyphs->bytes > 0 && glyphs->bitmap != 0)
-          free((char *) glyphs->bitmap);
+    if (font->glyphs != 0) {
+        for (i = 0, glyphs = font->glyphs; i < font->glyphs_used; i++, glyphs++) {
+            if (glyphs->name)
+              free(glyphs->name);
+            if (glyphs->bytes > 0 && glyphs->bitmap != 0)
+              free((char *) glyphs->bitmap);
+        }
+        free((char *) font->glyphs);
     }
 
-    for (i = 0, glyphs = font->unencoded; i < font->unencoded_used;
-         i++, glyphs++) {
-        if (glyphs->name)
-          free(glyphs->name);
-        if (glyphs->bytes > 0)
-          free((char *) glyphs->bitmap);
-        if (glyphs->unicode.map_size > 0)
-          free((char *) glyphs->unicode.map);
+    if (font->unencoded != 0) {
+        for (i = 0, glyphs = font->unencoded; i < font->unencoded_used;
+             i++, glyphs++) {
+            if (glyphs->name)
+              free(glyphs->name);
+            if (glyphs->bytes > 0)
+              free((char *) glyphs->bitmap);
+            if (glyphs->unicode.map_size > 0)
+              free((char *) glyphs->unicode.map);
+        }
+        free((char *) font->unencoded);
     }
-
-    if (font->glyphs != 0)
-      free((char *) font->glyphs);
-
-    if (font->unencoded != 0)
-      free((char *) font->unencoded);
 
     /*
      * Free up the overflow storage if it was used.
      */
-    for (i = 0, glyphs = font->overflow.glyphs; i < font->overflow.glyphs_used;
-         i++, glyphs++) {
-        if (glyphs->name != 0)
-          free(glyphs->name);
-        if (glyphs->bytes > 0)
-          free((char *) glyphs->bitmap);;
-        if (glyphs->unicode.map_size > 0)
-          free((char *) glyphs->unicode.map);
+    if (font->overflow.glyphs != 0) {
+        for (i = 0, glyphs = font->overflow.glyphs; i < font->overflow.glyphs_used;
+             i++, glyphs++) {
+            if (glyphs->name != 0)
+              free(glyphs->name);
+            if (glyphs->bytes > 0)
+              free((char *) glyphs->bitmap);;
+            if (glyphs->unicode.map_size > 0)
+              free((char *) glyphs->unicode.map);
+        }
+        free((char *) font->overflow.glyphs);
     }
-    if (font->overflow.glyphs != 0)
-      free((char *) font->overflow.glyphs);
 
     free((char *) font);
 }

--- a/bdf.c
+++ b/bdf.c
@@ -1400,6 +1400,15 @@ _bdf_parse_glyphs(char *line, unsigned int linelen, unsigned int lineno,
      * Check for the STARTCHAR field.
      */
     if (memcmp(line, "STARTCHAR", 9) == 0) {
+        if (p->flags & _BDF_GLYPH_BITS) {
+            /*
+             * Missing ENDCHAR field.
+             */
+            sprintf(nbuf, BDF_ERR_MISSING_FIELD, lineno, "ENDCHAR");
+            _bdf_add_acmsg(font, nbuf, strlen(nbuf));
+            return BDF_MISSING_ENDCHAR;
+        }
+
         /*
          * Set the character name in the parse info first until the
          * encoding can be checked for an unencoded character.

--- a/bdf.h
+++ b/bdf.h
@@ -371,6 +371,7 @@ typedef struct {
 #define BDF_MISSING_STARTCHAR -6
 #define BDF_MISSING_ENCODING  -7
 #define BDF_MISSING_BBX       -8
+#define BDF_BBX_TOO_BIG       -9
 
 #define BDF_NOT_CONSOLE_FONT  -10
 #define BDF_NOT_MF_FONT       -11

--- a/bdf.h
+++ b/bdf.h
@@ -381,6 +381,7 @@ typedef struct {
 #define BDF_PSF_CORRUPT_UTF8  -15
 #define BDF_PSF_BUFFER_OVRFL  -16
 #define BDF_PSF_UNSUPPORTED   -17
+#define BDF_MISSING_ENDCHAR   -18
 #define BDF_BAD_RANGE         -98
 #define BDF_EMPTY_FONT        -99
 #define BDF_INVALID_LINE      -100

--- a/bdf.h
+++ b/bdf.h
@@ -607,8 +607,8 @@ extern void bdf_set_modified(bdf_font_t *font, int modified);
 
 extern int bdf_has_xlfd_name(bdf_font_t *font);
 
-extern char *bdf_make_xlfd_name(bdf_font_t *font, char *foundry,
-                                char *family);
+extern char *bdf_make_xlfd_name(bdf_font_t *font, const char *foundry,
+                                const char *family);
 
 extern void bdf_update_name_from_properties(bdf_font_t *font);
 

--- a/fontgrid.c
+++ b/fontgrid.c
@@ -783,14 +783,11 @@ fontgrid_make_rgb_image(Fontgrid *fw, bdf_glyph_t *glyph)
     }
 }
 
-#if !GTK_CHECK_VERSION(3, 0, 0)
 static void
 fontgrid_draw_encoding(GtkWidget *w, gint x, gint y, gchar *num,
                        gint numlen)
 {
-    gint i, j, d;
     Fontgrid *fw = FONTGRID(w);
-    GdkPoint *dp;
 
     if (!gtk_widget_get_realized(w))
       return;
@@ -819,6 +816,7 @@ fontgrid_draw_encoding(GtkWidget *w, gint x, gint y, gchar *num,
     cairo_destroy(cr);
 }
 
+#if !GTK_CHECK_VERSION(3, 0, 0)
 static void
 fontgrid_draw_cells(GtkWidget *widget, gint32 start, gint32 end,
                     gboolean labels, gboolean glyphs)

--- a/gbdfed.c
+++ b/gbdfed.c
@@ -593,7 +593,7 @@ static void
 handle_modified_signal(GtkWidget *w, gpointer minfo, gpointer editor)
 {
     gbdfed_editor_t *ed = editors + GPOINTER_TO_UINT(editor);
-    gchar *prgname = g_get_prgname();
+    const gchar *prgname = g_get_prgname();
     FontgridModificationInfo *mi;
 
     mi = (FontgridModificationInfo *) minfo;

--- a/guigedit.c
+++ b/guigedit.c
@@ -342,7 +342,7 @@ update_font(GtkWidget *w, gpointer data)
     GlypheditRec *ge = glyph_editors + GPOINTER_TO_UINT(data);
     gbdfed_editor_t *ed = editors + ge->owner;
     const gchar *s;
-    gchar *prgname = g_get_prgname();
+    const gchar *prgname = g_get_prgname();
     gboolean unencoded;
     bdf_glyph_t *glyph;
     GlypheditOperation op;
@@ -1728,7 +1728,7 @@ glyph_modified(GtkWidget *w, gpointer cb, gpointer ged)
     GlypheditRec *ge = glyph_editors + GPOINTER_TO_UINT(ged);
     gbdfed_editor_t *ed = editors + ge->owner;
     GlypheditSignalInfo *si = (GlypheditSignalInfo *) cb;
-    gchar *prgname = g_get_prgname();
+    const gchar *prgname = g_get_prgname();
 
     if (si->metrics == 0)
       return;


### PR DESCRIPTION
Turns out FreeType’s been maintaining a fork of our BDF parser, and have produced a lot of fixes over the years.
Fuzzing bdf.c finds numerous deficiencies in input handling, so porting these changes should make the BDF parser less crash-prone.